### PR TITLE
Bugfix/win path separator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-cli",
-  "version": "3.5.12",
+  "version": "3.5.13",
   "description": "Official CLI for Direflow",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-component",
-  "version": "3.5.12",
+  "version": "3.5.13",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/packages/direflow-scripts/package.json
+++ b/packages/direflow-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "direflow-scripts",
-  "version": "3.5.12",
+  "version": "3.5.13",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "author": "Silind Software",

--- a/packages/direflow-scripts/src/config/config-overrides.ts
+++ b/packages/direflow-scripts/src/config/config-overrides.ts
@@ -3,7 +3,7 @@ import FilterWarningsPlugin from "webpack-filter-warnings-plugin";
 import { EnvironmentPlugin } from "webpack";
 import rimraf from "rimraf";
 import fs from "fs";
-import { resolve } from "path";
+import { resolve, format } from "path";
 import { PromiseTask } from "event-hooks-webpack-plugin/lib/tasks";
 import entryResolver from "../helpers/entryResolver";
 import {
@@ -20,8 +20,9 @@ import IDireflowConfig from "../types/DireflowConfig";
 
 export = function override(config: TConfig, env: string, options?: IOptions) {
   const originalEntry = [config.entry].flat() as string[];
+  console.log(format({ dir: "src", base: "index" }));
   const pathIndex = originalEntry.find(
-    entry => entry && entry.includes("src/index")
+    entry => entry && entry.includes(format({ dir: "src", base: "index" }))
   );
 
   if (!pathIndex) {

--- a/packages/direflow-scripts/src/config/config-overrides.ts
+++ b/packages/direflow-scripts/src/config/config-overrides.ts
@@ -20,7 +20,6 @@ import IDireflowConfig from "../types/DireflowConfig";
 
 export = function override(config: TConfig, env: string, options?: IOptions) {
   const originalEntry = [config.entry].flat() as string[];
-  console.log(format({ dir: "src", base: "index" }));
   const pathIndex = originalEntry.find(
     entry => entry && entry.includes(format({ dir: "src", base: "index" }))
   );

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -36,8 +36,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^4.0.3",
-    "direflow-component": "3.5.12",
-    "direflow-scripts": "3.5.12"
+    "direflow-component": "3.5.13",
+    "direflow-scripts": "3.5.13"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.0.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -39,8 +39,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^4.0.3",
-    "direflow-component": "3.5.12",
-    "direflow-scripts": "3.5.12"
+    "direflow-component": "3.5.13",
+    "direflow-scripts": "3.5.13"
   },
   "devDependencies": {
     {{#if eslint}}


### PR DESCRIPTION
Fix issue when direflow-scripts are unable to find an index file because of the hard-coded Unix path.